### PR TITLE
[TRAVIS] Moved CppUnit and Boost to addons.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 
 sudo: required
 
-compiler: 
+compiler:
 #  - gcc
   - clang
 
@@ -18,30 +18,32 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - boost-latest
     packages:
       - clang
       - gcc-4.8
       - g++-4.8
+      - libcppunit-dev
+      - libboost1.55-all-dev
+#      - libcrypto++-dev
+# Note: libcrypto++-dev is not yet whitelisted, nor usable in the packaged
+# version in Clang without editing a file (see below)
 
 before_install:
-  - sudo add-apt-repository -y ppa:boost-latest/ppa
-  - sudo apt-get update
-  - sudo apt-get install -y libcppunit-dev
   - sudo apt-get install -y libcrypto++-dev
-  - sudo apt-get install -y libboost1.55-all-dev
 # workaround for not having CMake 3.2
   - wget http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
   - tar -xzf cmake-3.2.3-Linux-x86_64.tar.gz
   - sudo cp -fR cmake-3.2.3-Linux-x86_64/* /usr
 # Fix the dependant-name bug in crypto++
   - sudo sed -i 's/\tCheckSize/\tthis->CheckSize/g' /usr/include/cryptopp/secblock.h
-  
+
 before_script:
   - mkdir build
   - cd build
   - cmake ..
 
-script: make && make test || (cat Testing/Temporary/LastTest.log && false)
+script: make -j2 && make test || (cat Testing/Temporary/LastTest.log && false)
 
 notifications:
   email:


### PR DESCRIPTION
* Crypto++ could not be moved since it is not whitelisted, nor
  is it a version that Clang can use without editing.
* CMake 3.2 is in no whitelisted repo that I can see.