### PR TITLE
[BUILD] Re-enabled accidentally-deleted tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ find_package(Boost
 # required.
 find_package(Crypto++)
 
+# CppUnit is required for the unit testing.
+find_package(CppUnit)
+
+if (CPPUNIT_FOUND)
+    enable_testing()
+endif()
+
 add_subdirectory(odin)
 add_subdirectory(munin)
 add_subdirectory(paradice)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,10 +13,10 @@ set (test_SOURCES
     telnet_subnegotiation_router_fixture.cpp
 )
 
-find_package(CppUnit)
+
+enable_testing()
 
 if (CPPUNIT_FOUND)
-    enable_testing()
     add_executable(paradice_tester ${test_SOURCES})
 
     target_include_directories(paradice_tester


### PR DESCRIPTION
enable_testing only applies from the current directory, so
really should be called in the root directory.