### PR TITLE
Intro screen now accepts enter key at any moment.

### DIFF
--- a/hugin/intro_screen.cpp
+++ b/hugin/intro_screen.cpp
@@ -269,6 +269,10 @@ void intro_screen::do_event(boost::any const &ev)
             
             handled = true;
         }
+        else if (vk->key == terminalpp::vk::enter)
+        {
+            pimpl_->on_login_clicked();
+        }
     }
     
     if (!handled)


### PR DESCRIPTION
By default, causes the equivalent behaviour to the login button
being pressed.  New button still reacts as before.

Closes #142

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kazdragon/paradice9/183)
<!-- Reviewable:end -->
