### PR TITLE
Lazy card initialization#186

### DIFF
--- a/hugin/account_creation_screen.cpp
+++ b/hugin/account_creation_screen.cpp
@@ -60,24 +60,21 @@ struct account_creation_screen::impl
     // ======================================================================
     void on_account_creation_ok()
     {
-        if (on_account_created_)
-        {
-            auto document = name_field_->get_document();
-            auto elements = document->get_line(0);
-            auto name = to_string(elements);
-            
-            document = password_field_->get_document();
-            elements = document->get_line(0);
-            
-            auto password = to_string(elements);
-            
-            document = password_verify_field_->get_document();
-            elements = document->get_line(0);
-            
-            auto password_verify = to_string(elements);
-            
-            on_account_created_(name, password, password_verify);
-        }
+        auto document = name_field_->get_document();
+        auto elements = document->get_line(0);
+        auto name = to_string(elements);
+        
+        document = password_field_->get_document();
+        elements = document->get_line(0);
+        
+        auto password = to_string(elements);
+        
+        document = password_verify_field_->get_document();
+        elements = document->get_line(0);
+        
+        auto password_verify = to_string(elements);
+        
+        self_.on_account_created(name, password, password_verify);
     }
     
     // ======================================================================
@@ -85,10 +82,7 @@ struct account_creation_screen::impl
     // ======================================================================
     void on_account_creation_cancelled()
     {
-        if (on_account_creation_cancelled_)
-        {
-            on_account_creation_cancelled_();
-        }
+        self_.on_account_creation_cancelled();
     }
     
     account_creation_screen                  &self_;
@@ -99,10 +93,7 @@ struct account_creation_screen::impl
     std::shared_ptr<munin::edit>              password_verify_field_;
     std::shared_ptr<munin::button>            ok_button_;
     std::shared_ptr<munin::button>            cancel_button_;
-    std::function<void (std::string const &, 
-                        std::string const &, 
-                        std::string const &)> on_account_created_;
-    std::function<void ()>                    on_account_creation_cancelled_;
+
     std::vector<boost::signals::connection>   connections_;
 };
 

--- a/hugin/account_creation_screen.cpp
+++ b/hugin/account_creation_screen.cpp
@@ -48,6 +48,14 @@ namespace hugin {
 struct account_creation_screen::impl
 {
     // ======================================================================
+    // CONSTRUCTOR
+    // ======================================================================
+    impl(account_creation_screen &self)
+      : self_(self)
+    {
+    }
+     
+    // ======================================================================
     // ON_ACCOUNT_CREATION_OK
     // ======================================================================
     void on_account_creation_ok()
@@ -83,6 +91,8 @@ struct account_creation_screen::impl
         }
     }
     
+    account_creation_screen                  &self_;
+    
     // Account Creation components
     std::shared_ptr<munin::edit>              name_field_;
     std::shared_ptr<munin::edit>              password_field_;
@@ -100,7 +110,7 @@ struct account_creation_screen::impl
 // CONSTRUCTOR
 // ==========================================================================
 account_creation_screen::account_creation_screen()
-    : pimpl_(std::make_shared<impl>())
+    : pimpl_(std::make_shared<impl>(std::ref(*this)))
 {
     using namespace terminalpp::literals;
     
@@ -256,27 +266,6 @@ void account_creation_screen::clear()
     
     document = pimpl_->password_verify_field_->get_document();
     document->delete_text(std::make_pair(odin::u32(0), document->get_text_size()));
-}
-
-// ==========================================================================
-// ON_ACCOUNT_CREATED
-// ==========================================================================
-void account_creation_screen::on_account_created(
-    std::function<
-        void (std::string const &, 
-              std::string const &, 
-              std::string const &)> const &callback)
-{
-    pimpl_->on_account_created_ = callback;
-}
-
-// ==========================================================================
-// ON_ACCOUNT_CREATION_CANCELLED
-// ==========================================================================
-void account_creation_screen::on_account_creation_cancelled(
-    std::function<void ()> const &callback)
-{
-    pimpl_->on_account_creation_cancelled_ = callback;
 }
 
 // ==========================================================================

--- a/hugin/account_creation_screen.hpp
+++ b/hugin/account_creation_screen.hpp
@@ -59,17 +59,16 @@ public :
     /// \brief Set a function to be called when the user inputs the details
     /// for the creation of an account.
     //* =====================================================================
-    void on_account_created(
-        std::function<
-            void (std::string const &account_name,
-                  std::string const &password,
-                  std::string const &password_verify)> const &callback);
+    boost::signal<
+        void (std::string const &account_name,
+              std::string const &password,
+              std::string const &password_verify)> on_account_created;
     
     //* =====================================================================
     /// \brief Set a function to be called when the user cancels the creation
     /// of an account.
     //* =====================================================================
-    void on_account_creation_cancelled(std::function<void ()> const &callback);
+    boost::signal<void ()> on_account_creation_cancelled;
     
 protected :
     //* =====================================================================

--- a/hugin/character_creation_screen.cpp
+++ b/hugin/character_creation_screen.cpp
@@ -48,18 +48,23 @@ namespace hugin {
 struct character_creation_screen::impl
 {
     // ======================================================================
+    // CONSTRUCTOR
+    // ======================================================================
+    impl(character_creation_screen &self)
+      : self_(self)
+    {
+    }
+    
+    // ======================================================================
     // ON_CHARACTER_CREATION_OK
     // ======================================================================
     void on_character_creation_ok()
     {
-        if (on_character_created_)
-        {
-            auto document = name_field_->get_document();
-            auto elements = document->get_line(0);
-            auto name = to_string(elements);
-            
-            on_character_created_(name, gm_toggle_->get_toggle());
-        }
+        auto document = name_field_->get_document();
+        auto elements = document->get_line(0);
+        auto name = to_string(elements);
+        
+        self_.on_character_created(name, gm_toggle_->get_toggle());
     }
     
     // ======================================================================
@@ -67,27 +72,24 @@ struct character_creation_screen::impl
     // ======================================================================
     void on_character_creation_cancelled()
     {
-        if (on_character_creation_cancelled_)
-        {
-            on_character_creation_cancelled_();
-        }
+        self_.on_character_creation_cancelled();
     }
     
+    character_creation_screen              &self_;
+
     // Character Creation components
-    std::shared_ptr<munin::edit>                    name_field_;
-    std::shared_ptr<munin::toggle_button>           gm_toggle_;
-    std::shared_ptr<munin::button>                  ok_button_;
-    std::shared_ptr<munin::button>                  cancel_button_;
-    std::function<void (std::string const &, bool)> on_character_created_;
-    std::function<void ()>                          on_character_creation_cancelled_;
-    std::vector<boost::signals::connection>         connections_;
+    std::shared_ptr<munin::edit>            name_field_;
+    std::shared_ptr<munin::toggle_button>   gm_toggle_;
+    std::shared_ptr<munin::button>          ok_button_;
+    std::shared_ptr<munin::button>          cancel_button_;
+    std::vector<boost::signals::connection> connections_;
 };
 
 // ==========================================================================
 // CONSTRUCTOR
 // ==========================================================================
 character_creation_screen::character_creation_screen()
-    : pimpl_(std::make_shared<impl>())
+    : pimpl_(std::make_shared<impl>(std::ref(*this)))
 {
     using namespace terminalpp::literals;
     
@@ -217,24 +219,6 @@ void character_creation_screen::clear()
     document->delete_text({odin::u32(0), document->get_text_size()});
     
     pimpl_->gm_toggle_->set_toggle(false);
-}
-
-// ==========================================================================
-// ON_CHARACTER_CREATED
-// ==========================================================================
-void character_creation_screen::on_character_created(
-    std::function<void (std::string const &, bool)> const &callback)
-{
-    pimpl_->on_character_created_ = callback;
-}
-
-// ==========================================================================
-// ON_CHARACTER_CREATION_CANCELLED
-// ==========================================================================
-void character_creation_screen::on_character_creation_cancelled(
-    std::function<void ()> const &callback)
-{
-    pimpl_->on_character_creation_cancelled_ = callback;
 }
 
 // ==========================================================================

--- a/hugin/character_creation_screen.hpp
+++ b/hugin/character_creation_screen.hpp
@@ -59,18 +59,15 @@ public :
     /// \brief Set a function to be called when the user inputs the details
     /// for the creation of an character.
     //* =====================================================================
-    void on_character_created(
-        std::function<void (
-            std::string const &character_name,
-            bool               is_gm)> const &callback);
+    boost::signal<
+        void (std::string const &name, bool is_gm)> on_character_created;
     
     //* =====================================================================
     /// \brief Set a function to be called when the user cancels the creation
     /// of an character.
     //* =====================================================================
-    void on_character_creation_cancelled(
-        std::function<void ()> const &callback);
-    
+    boost::signal<void ()> on_character_creation_cancelled;
+
 protected :
     //* =====================================================================
     /// \brief Called by event().  Derived classes must override this 

--- a/hugin/character_selection_screen.cpp
+++ b/hugin/character_selection_screen.cpp
@@ -42,9 +42,6 @@ namespace hugin {
 // ==========================================================================
 struct character_selection_screen::impl
 {
-    std::function<void ()>                           on_new_character_;
-    std::function<void (std::string const &)>        on_character_selected_;
-    
     std::vector<std::pair<std::string, std::string>> characters_;
     
     std::shared_ptr<munin::image>                    character_list_;
@@ -141,24 +138,6 @@ void character_selection_screen::set_character_names(
 }
 
 // ==========================================================================
-// ON_NEW_CHARACTER
-// ==========================================================================
-void character_selection_screen::on_new_character(
-    std::function<void ()> const &callback)
-{
-    pimpl_->on_new_character_ = callback;
-}
-
-// ==========================================================================
-// ON_CHARACTER_SELECTED
-// ==========================================================================
-void character_selection_screen::on_character_selected(
-    std::function<void (std::string const &)> const &callback)
-{
-    pimpl_->on_character_selected_ = callback;
-}
-
-// ==========================================================================
 // DO_EVENT
 // ==========================================================================
 void character_selection_screen::do_event(boost::any const &event)
@@ -169,19 +148,15 @@ void character_selection_screen::do_event(boost::any const &event)
     {
         if (vk->key == terminalpp::vk::plus)
         {
-            if (pimpl_->on_new_character_)
-            {
-                pimpl_->on_new_character_();
-            }
+            on_new_character();
         }
         else
         {
             unsigned int selection = char(vk->key) - '0';
             
-            if (selection < pimpl_->characters_.size()
-             && pimpl_->on_character_selected_ != NULL)
+            if (selection < pimpl_->characters_.size())
             {
-                pimpl_->on_character_selected_(
+                on_character_selected(
                     pimpl_->characters_[selection].first);
             }
         }

--- a/hugin/character_selection_screen.hpp
+++ b/hugin/character_selection_screen.hpp
@@ -70,15 +70,13 @@ public :
     /// \brief Provide a function to be called if the user opts to create
     /// a new character.
     //* =====================================================================
-    void on_new_character(
-        std::function<void ()> const &callback);
+    boost::signal<void ()> on_new_character;
     
     //* =====================================================================
     /// \brief Provide a function to be called if the user opts to use an
     /// existing character.
     //* =====================================================================
-    void on_character_selected(
-        std::function<void (std::string const &)> const &callback);
+    boost::signal<void (std::string const &name)> on_character_selected;
     
 protected :
     //* =====================================================================

--- a/hugin/main_screen.cpp
+++ b/hugin/main_screen.cpp
@@ -75,14 +75,6 @@ struct main_screen::impl
         }
     }
 
-    // ======================================================================
-    // FIRE_HELP_CLOSED
-    // ======================================================================
-    void fire_help_closed()
-    {
-        self_.on_help_closed();
-    }
-    
     main_screen                           &self_;
     
     std::shared_ptr<wholist>               wholist_;

--- a/hugin/main_screen.cpp
+++ b/hugin/main_screen.cpp
@@ -95,9 +95,6 @@ struct main_screen::impl
     bool                                   help_field_visible_;
     std::shared_ptr<active_encounter_view> active_encounter_view_;
     bool                                   active_encounter_view_visible_;
-    
-    std::function<void (std::string const &)> on_input_entered_;
-    std::function<void ()>                 on_help_closed_;
 };
 
 // ==========================================================================

--- a/hugin/main_screen.cpp
+++ b/hugin/main_screen.cpp
@@ -51,8 +51,9 @@ struct main_screen::impl
     // ======================================================================
     // CONSTRUCTOR
     // ======================================================================
-    impl()
-        : help_field_visible_(false)
+    impl(main_screen &self)
+        : self_(self)
+        , help_field_visible_(false)
         , active_encounter_view_visible_(false)
     {
     } 
@@ -62,18 +63,15 @@ struct main_screen::impl
     // ======================================================================
     void on_input_entered()
     {
-        if (on_input_entered_)
+        auto document = input_field_->get_document();
+        auto elements = document->get_line(0);
+        auto input = to_string(elements); 
+
+        document->delete_text({odin::u32(0), document->get_text_size()});
+
+        if (!input.empty())
         {
-            auto document = input_field_->get_document();
-            auto elements = document->get_line(0);
-            auto input = to_string(elements); 
-
-            document->delete_text({odin::u32(0), document->get_text_size()});
-
-            if (!input.empty())
-            {
-                on_input_entered_(input);
-            }
+            self_.on_input_entered(input);
         }
     }
 
@@ -82,11 +80,10 @@ struct main_screen::impl
     // ======================================================================
     void fire_help_closed()
     {
-        if (on_help_closed_)
-        {
-            on_help_closed_();
-        }
+        self_.on_help_closed();
     }
+    
+    main_screen                           &self_;
     
     std::shared_ptr<wholist>               wholist_;
     std::shared_ptr<command_prompt>        input_field_;
@@ -107,7 +104,7 @@ struct main_screen::impl
 // CONSTRUCTOR
 // ==========================================================================
 main_screen::main_screen()
-  : pimpl_(std::make_shared<impl>())
+  : pimpl_(std::make_shared<impl>(std::ref(*this)))
 {
     using namespace terminalpp::literals;
 
@@ -173,15 +170,6 @@ void main_screen::clear()
     update_wholist({});
     hide_help_window();
     pimpl_->input_field_->clear_history();
-}
-
-// ==========================================================================
-// ON_INPUT_ENTERED
-// ==========================================================================
-void main_screen::on_input_entered(
-    std::function<void (std::string const &)> const &callback)
-{
-    pimpl_->on_input_entered_ = callback;
 }
 
 // ==========================================================================
@@ -287,14 +275,6 @@ void main_screen::set_help_window_text(terminalpp::string const &text)
     auto document = pimpl_->help_field_->get_document();
     document->delete_text({odin::u32(0), document->get_text_size()});
     document->insert_text(text);
-}
-
-// ==========================================================================
-// ON_HELP_CLOSED
-// ==========================================================================
-void main_screen::on_help_closed(std::function<void ()> const &callback)
-{
-    pimpl_->on_help_closed_ = callback;
 }
 
 // ==========================================================================

--- a/hugin/main_screen.hpp
+++ b/hugin/main_screen.hpp
@@ -59,8 +59,7 @@ public :
     /// \brief Set a function to be called when the user inputs a command
     /// on the main screen.
     //* =====================================================================
-    void on_input_entered(
-        std::function<void (std::string const &)> const &callback);
+    boost::signal<void (std::string const &input)> on_input_entered;
     
     //* =====================================================================
     /// \brief Adds output to the output text area on the main screen.
@@ -113,8 +112,8 @@ public :
     /// \brief Register a callback for when the close button on the help
     /// screen is called.
     //* =====================================================================
-    void on_help_closed(std::function<void ()> const &callback);
-    
+    boost::signal<void ()> on_help_closed;
+
 protected :
     //* =====================================================================
     /// \brief Called by event().  Derived classes must override this 

--- a/hugin/password_change_screen.cpp
+++ b/hugin/password_change_screen.cpp
@@ -47,29 +47,34 @@ namespace hugin {
 struct password_change_screen::impl
 {
     // ======================================================================
+    // CONSTRUCTOR
+    // ======================================================================
+    impl(password_change_screen &self)
+      : self_(self)
+     {
+     }
+
+    // ======================================================================
     // ON_PASSWORD_CHANGE_OK
     // ======================================================================
     void on_password_change_ok()
     {
-        if (on_password_changed_)
-        {
-            auto document = old_password_field_->get_document();
-            auto elements = document->get_line(0);
-            auto old_password = to_string(elements);
-            
-            document = new_password_field_->get_document();
-            elements = document->get_line(0);
-            
-            auto new_password = to_string(elements);
-            
-            document = new_password_verify_field_->get_document();
-            elements = document->get_line(0);
-            
-            auto new_password_verify = to_string(elements);
-            
-            on_password_changed_(
-                old_password, new_password, new_password_verify);
-        }
+        auto document = old_password_field_->get_document();
+        auto elements = document->get_line(0);
+        auto old_password = to_string(elements);
+        
+        document = new_password_field_->get_document();
+        elements = document->get_line(0);
+        
+        auto new_password = to_string(elements);
+        
+        document = new_password_verify_field_->get_document();
+        elements = document->get_line(0);
+        
+        auto new_password_verify = to_string(elements);
+        
+        self_.on_password_changed(
+            old_password, new_password, new_password_verify);
     }
     
     // ======================================================================
@@ -77,11 +82,10 @@ struct password_change_screen::impl
     // ======================================================================
     void on_password_change_cancelled()
     {
-        if (on_password_change_cancelled_)
-        {
-            on_password_change_cancelled_();
-        }
+        self_.on_password_change_cancelled();
     }
+
+    password_change_screen                 &self_;
     
     // Password Change components
     std::shared_ptr<munin::edit>            old_password_field_;
@@ -89,12 +93,6 @@ struct password_change_screen::impl
     std::shared_ptr<munin::edit>            new_password_verify_field_;
     std::shared_ptr<munin::button>          ok_button_;
     std::shared_ptr<munin::button>          cancel_button_;
-    std::function<
-        void (
-            std::string const &, 
-            std::string const &, 
-            std::string const &)>           on_password_changed_;
-    std::function<void ()>                  on_password_change_cancelled_;
     std::vector<boost::signals::connection> connections_;
 };
 
@@ -102,7 +100,7 @@ struct password_change_screen::impl
 // CONSTRUCTOR
 // ==========================================================================
 password_change_screen::password_change_screen()
-    : pimpl_(std::make_shared<impl>())
+    : pimpl_(std::make_shared<impl>(std::ref(*this)))
 {
     using namespace terminalpp::literals;
 
@@ -262,28 +260,6 @@ void password_change_screen::clear()
     
     document = pimpl_->new_password_verify_field_->get_document();
     document->delete_text({odin::u32(0), document->get_text_size()});
-}
-
-// ==========================================================================
-// ON_PASSWORD_CHANGED
-// ==========================================================================
-void password_change_screen::on_password_changed(
-    std::function<
-        void (
-            std::string const &, 
-            std::string const &, 
-            std::string const &)> const &callback)
-{
-    pimpl_->on_password_changed_ = callback;
-}
-
-// ==========================================================================
-// ON_PASSWORD_CHANGE_CANCELLED
-// ==========================================================================
-void password_change_screen::on_password_change_cancelled(
-    std::function<void ()> const &callback)
-{
-    pimpl_->on_password_change_cancelled_ = callback;
 }
 
 // ==========================================================================

--- a/hugin/password_change_screen.hpp
+++ b/hugin/password_change_screen.hpp
@@ -58,18 +58,17 @@ public :
     /// \brief Set a function to be called when the user inputs the details
     /// for the change of a password.
     //* =====================================================================
-    void on_password_changed(
-        std::function<
-            void (std::string const &old_password
-                , std::string const &new_password
-                , std::string const &new_password_verify)> const &callback);
+    boost::signal<
+        void (std::string const &old_password
+            , std::string const &new_password
+            , std::string const &new_password_verify)> on_password_changed;
     
     //* =====================================================================
     /// \brief Set a function to be called when the user cancels the change
     /// of a password.
     //* =====================================================================
-    void on_password_change_cancelled(std::function<void ()> const &callback);
-    
+    boost::signal<void ()> on_password_change_cancelled;
+
 protected :
     //* =====================================================================
     /// \brief Called by event().  Derived classes must override this 

--- a/hugin/user_interface.cpp
+++ b/hugin/user_interface.cpp
@@ -146,6 +146,11 @@ private:
         {
             create_intro_screen();
         }
+        else if (face_name == hugin::FACE_ACCOUNT_CREATION
+         && !account_creation_screen_)
+        {
+            create_account_creation_screen();
+        }
     }
     
     // ======================================================================
@@ -158,6 +163,21 @@ private:
         intro_screen_->on_new_account.connect(self_.on_new_account);
 
         active_screen_->add_face(intro_screen_, hugin::FACE_INTRO);
+    }
+
+    // ======================================================================
+    // CREATE_ACCOUNT_CREATION_SCREEN
+    // ======================================================================
+    void create_account_creation_screen()
+    {
+        account_creation_screen_ = std::make_shared<account_creation_screen>();
+        account_creation_screen_->on_account_created.connect(
+            self_.on_account_created);
+        account_creation_screen_->on_account_creation_cancelled.connect(
+            self_.on_account_creation_cancelled);
+            
+        active_screen_->add_face(
+            account_creation_screen_, hugin::FACE_ACCOUNT_CREATION);
     }
 
     // ======================================================================
@@ -185,15 +205,12 @@ user_interface::user_interface(boost::asio::strand &strand)
     using namespace terminalpp::literals;
 
     pimpl_->active_screen_              = std::make_shared<munin::card>();
-    pimpl_->account_creation_screen_    = std::make_shared<account_creation_screen>();
     pimpl_->character_creation_screen_  = std::make_shared<character_creation_screen>();
     pimpl_->character_selection_screen_ = std::make_shared<character_selection_screen>();
     pimpl_->main_screen_                = std::make_shared<main_screen>();
     pimpl_->gm_tools_screen_            = std::make_shared<gm_tools_screen>();
     pimpl_->status_bar_                 = std::make_shared<munin::status_bar>();
 
-    pimpl_->active_screen_->add_face(
-        pimpl_->account_creation_screen_, hugin::FACE_ACCOUNT_CREATION);
     pimpl_->active_screen_->add_face(
         pimpl_->character_selection_screen_, hugin::FACE_CHAR_SELECTION);
     pimpl_->active_screen_->add_face(
@@ -255,7 +272,14 @@ void user_interface::clear_intro_screen()
 // ==========================================================================
 void user_interface::clear_account_creation_screen()
 {
-    pimpl_->async([pimpl_=pimpl_]{pimpl_->account_creation_screen_->clear();});
+    pimpl_->async(
+        [pimpl_=pimpl_]
+        {
+            if (pimpl_->account_creation_screen_)
+            {
+                pimpl_->account_creation_screen_->clear();
+            }
+        });
 }
 
 // ==========================================================================
@@ -295,27 +319,6 @@ void user_interface::clear_password_change_screen()
                 pimpl_->password_change_screen_->clear();
             }
         });
-}
-
-// ==========================================================================
-// ON_ACCOUNT_CREATED
-// ==========================================================================
-void user_interface::on_account_created(
-    std::function<
-        void (std::string const &, 
-              std::string const &, 
-              std::string const &)> const &callback)
-{
-    pimpl_->account_creation_screen_->on_account_created(callback);
-}
-
-// ==========================================================================
-// ON_ACCOUNT_CREATION_CANCELLED
-// ==========================================================================
-void user_interface::on_account_creation_cancelled(
-    std::function<void ()> const &callback)
-{
-    pimpl_->account_creation_screen_->on_account_creation_cancelled(callback);
 }
 
 // ==========================================================================

--- a/hugin/user_interface.cpp
+++ b/hugin/user_interface.cpp
@@ -151,6 +151,11 @@ private:
         {
             create_account_creation_screen();
         }
+        else if (face_name == hugin::FACE_MAIN
+         && !main_screen_)
+        {
+            create_main_screen();
+        }
     }
     
     // ======================================================================
@@ -181,6 +186,18 @@ private:
     }
 
     // ======================================================================
+    // CREATE_MAIN_SCREEN
+    // ======================================================================
+    void create_main_screen()
+    {
+        main_screen_ = std::make_shared<main_screen>();
+        main_screen_->on_input_entered.connect(self_.on_input_entered);
+        main_screen_->on_help_closed.connect(self_.on_help_closed);
+        
+        active_screen_->add_face(main_screen_, hugin::FACE_MAIN);
+    }
+
+    // ======================================================================
     // CREATE_PASSWORD_CHANGE_SCREEN
     // ======================================================================
     void create_password_change_screen()
@@ -207,7 +224,6 @@ user_interface::user_interface(boost::asio::strand &strand)
     pimpl_->active_screen_              = std::make_shared<munin::card>();
     pimpl_->character_creation_screen_  = std::make_shared<character_creation_screen>();
     pimpl_->character_selection_screen_ = std::make_shared<character_selection_screen>();
-    pimpl_->main_screen_                = std::make_shared<main_screen>();
     pimpl_->gm_tools_screen_            = std::make_shared<gm_tools_screen>();
     pimpl_->status_bar_                 = std::make_shared<munin::status_bar>();
 
@@ -216,12 +232,9 @@ user_interface::user_interface(boost::asio::strand &strand)
     pimpl_->active_screen_->add_face(
         pimpl_->character_creation_screen_, hugin::FACE_CHAR_CREATION);
     pimpl_->active_screen_->add_face(
-        pimpl_->main_screen_, hugin::FACE_MAIN);
-    pimpl_->active_screen_->add_face(
         pimpl_->gm_tools_screen_, hugin::FACE_GM_TOOLS);
-    
-    pimpl_->active_screen_->select_face(hugin::FACE_INTRO);
-    pimpl_->active_face_ = hugin::FACE_INTRO;
+
+    pimpl_->select_face(hugin::FACE_INTRO);    
 
     // Create a container that has a single spacer element and ... A CLOCK!
     auto clock_container = std::make_shared<munin::basic_container>();
@@ -287,7 +300,14 @@ void user_interface::clear_account_creation_screen()
 // ==========================================================================
 void user_interface::clear_character_selection_screen()
 {
-    pimpl_->async([pimpl_=pimpl_]{pimpl_->character_selection_screen_->clear();});
+    pimpl_->async(
+        [pimpl_=pimpl_]
+        {
+            if (pimpl_->character_selection_screen_)
+            {
+                pimpl_->character_selection_screen_->clear();
+            }
+        });
 }
 
 // ==========================================================================
@@ -295,7 +315,14 @@ void user_interface::clear_character_selection_screen()
 // ==========================================================================
 void user_interface::clear_character_creation_screen()
 {
-    pimpl_->async([pimpl_=pimpl_]{pimpl_->character_creation_screen_->clear();});
+    pimpl_->async(
+        [pimpl_=pimpl_]
+        {
+            if (pimpl_->character_creation_screen_)
+            {
+                pimpl_->character_creation_screen_->clear();
+            }
+        });
 }
 
 // ==========================================================================
@@ -303,7 +330,14 @@ void user_interface::clear_character_creation_screen()
 // ==========================================================================
 void user_interface::clear_main_screen()
 {
-    pimpl_->async([pimpl_=pimpl_]{pimpl_->main_screen_->clear();});
+    pimpl_->async(
+        [pimpl_=pimpl_]
+        {
+            if (pimpl_->main_screen_)
+            {
+                pimpl_->main_screen_->clear();
+            }
+        });
 }
 
 // ==========================================================================
@@ -319,15 +353,6 @@ void user_interface::clear_password_change_screen()
                 pimpl_->password_change_screen_->clear();
             }
         });
-}
-
-// ==========================================================================
-// ON_INPUT_ENTERED
-// ==========================================================================
-void user_interface::on_input_entered(
-    std::function<void (std::string const &)> const &callback)
-{
-    pimpl_->main_screen_->on_input_entered(callback);
 }
 
 // ==========================================================================
@@ -521,14 +546,6 @@ void user_interface::show_help_window()
 void user_interface::hide_help_window()
 {
     pimpl_->async([pimpl_=pimpl_]{pimpl_->main_screen_->hide_help_window();});
-}
-
-// ==========================================================================
-// ON_HELP_CLOSED
-// ==========================================================================
-void user_interface::on_help_closed(std::function<void ()> const &callback)
-{
-    pimpl_->main_screen_->on_help_closed(callback);
 }
 
 // ==========================================================================

--- a/hugin/user_interface.cpp
+++ b/hugin/user_interface.cpp
@@ -141,8 +141,25 @@ private:
         {
             create_password_change_screen();
         }
+        else if (face_name == hugin::FACE_INTRO
+         && !intro_screen_)
+        {
+            create_intro_screen();
+        }
     }
     
+    // ======================================================================
+    // CREATE_INTRO_SCREEN
+    // ======================================================================
+    void create_intro_screen()
+    {
+        intro_screen_ = std::make_shared<intro_screen>();
+        intro_screen_->on_login.connect(self_.on_login);
+        intro_screen_->on_new_account.connect(self_.on_new_account);
+
+        active_screen_->add_face(intro_screen_, hugin::FACE_INTRO);
+    }
+
     // ======================================================================
     // CREATE_PASSWORD_CHANGE_SCREEN
     // ======================================================================
@@ -153,6 +170,9 @@ private:
             self_.on_password_changed);
         password_change_screen_->on_password_change_cancelled.connect(
             self_.on_password_change_cancelled);
+            
+        active_screen_->add_face(
+            password_change_screen_, hugin::FACE_PASSWORD_CHANGE);
     }
 };
 
@@ -165,7 +185,6 @@ user_interface::user_interface(boost::asio::strand &strand)
     using namespace terminalpp::literals;
 
     pimpl_->active_screen_              = std::make_shared<munin::card>();
-    pimpl_->intro_screen_               = std::make_shared<intro_screen>();
     pimpl_->account_creation_screen_    = std::make_shared<account_creation_screen>();
     pimpl_->character_creation_screen_  = std::make_shared<character_creation_screen>();
     pimpl_->character_selection_screen_ = std::make_shared<character_selection_screen>();
@@ -173,8 +192,6 @@ user_interface::user_interface(boost::asio::strand &strand)
     pimpl_->gm_tools_screen_            = std::make_shared<gm_tools_screen>();
     pimpl_->status_bar_                 = std::make_shared<munin::status_bar>();
 
-    pimpl_->active_screen_->add_face(
-        pimpl_->intro_screen_, hugin::FACE_INTRO);
     pimpl_->active_screen_->add_face(
         pimpl_->account_creation_screen_, hugin::FACE_ACCOUNT_CREATION);
     pimpl_->active_screen_->add_face(
@@ -223,7 +240,14 @@ user_interface::user_interface(boost::asio::strand &strand)
 // ==========================================================================
 void user_interface::clear_intro_screen()
 {
-    pimpl_->async([pimpl_=pimpl_]{pimpl_->intro_screen_->clear();});
+    pimpl_->async(
+        [pimpl_=pimpl_]
+        {
+            if (pimpl_->intro_screen_)
+            {
+                pimpl_->intro_screen_->clear();
+            }
+        });
 }
 
 // ==========================================================================
@@ -271,23 +295,6 @@ void user_interface::clear_password_change_screen()
                 pimpl_->password_change_screen_->clear();
             }
         });
-}
-
-// ==========================================================================
-// ON_LOGIN
-// ==========================================================================
-void user_interface::on_login(
-    std::function<void (std::string const &, std::string const &)> const &callback)
-{
-    pimpl_->intro_screen_->on_login.connect(callback);
-}
-
-// ==========================================================================
-// ON_NEW_ACCOUNT
-// ==========================================================================
-void user_interface::on_new_account(std::function<void ()> const &callback)
-{
-    pimpl_->intro_screen_->on_new_account.connect(callback);
 }
 
 // ==========================================================================

--- a/hugin/user_interface.cpp
+++ b/hugin/user_interface.cpp
@@ -142,6 +142,11 @@ struct user_interface::impl
         {
             create_character_creation_screen();
         }
+        else if (face_name == hugin::FACE_GM_TOOLS
+         && !gm_tools_screen_)
+        {
+            create_gm_tools_screen();
+        }
     }
 
 private:
@@ -251,6 +256,21 @@ private:
         active_screen_->add_face(
             password_change_screen_, hugin::FACE_PASSWORD_CHANGE);
     }
+
+    // ======================================================================
+    // CREATE_GM_TOOLS_SCREEN
+    // ======================================================================
+    void create_gm_tools_screen()
+    {
+        gm_tools_screen_ = std::make_shared<gm_tools_screen>();
+        gm_tools_screen_->on_back.connect(self_.on_gm_tools_back);
+        gm_tools_screen_->on_fight_beast.connect(self_.on_gm_fight_beast);
+        gm_tools_screen_->on_fight_encounter.connect(
+            self_.on_gm_fight_encounter);
+        
+        active_screen_->add_face(
+            gm_tools_screen_, hugin::FACE_GM_TOOLS);
+    }
 };
 
 // ==========================================================================
@@ -262,11 +282,7 @@ user_interface::user_interface(boost::asio::strand &strand)
     using namespace terminalpp::literals;
 
     pimpl_->active_screen_              = std::make_shared<munin::card>();
-    pimpl_->gm_tools_screen_            = std::make_shared<gm_tools_screen>();
     pimpl_->status_bar_                 = std::make_shared<munin::status_bar>();
-
-    pimpl_->active_screen_->add_face(
-        pimpl_->gm_tools_screen_, hugin::FACE_GM_TOOLS);
 
     pimpl_->select_face(hugin::FACE_INTRO);    
 
@@ -390,32 +406,6 @@ void user_interface::clear_password_change_screen()
 }
 
 // ==========================================================================
-// ON_GM_TOOLS_BACK
-// ==========================================================================
-void user_interface::on_gm_tools_back(std::function<void ()> const &callback)
-{
-    pimpl_->gm_tools_screen_->on_back.connect(callback);
-}
-
-// ==========================================================================
-// ON_GM_FIGHT_BEAST
-// ==========================================================================
-void user_interface::on_gm_fight_beast(
-    std::function<void (std::shared_ptr<paradice::beast> const &)> const &callback)
-{
-    pimpl_->gm_tools_screen_->on_fight_beast.connect(callback);
-}
-
-// ==========================================================================
-// ON_GM_FIGHT_ENCOUNTER
-// ==========================================================================
-void user_interface::on_gm_fight_encounter(
-    std::function<void (std::shared_ptr<paradice::encounter> const &)> const &callback)
-{
-    pimpl_->gm_tools_screen_->on_fight_encounter.connect(callback);
-}
-
-// ==========================================================================
 // SHOW_ACTIVE_ENCOUNTER_WINDOW
 // ==========================================================================
 void user_interface::show_active_encounter_window()
@@ -460,6 +450,7 @@ void user_interface::set_character_names(
 void user_interface::set_beasts(
     std::vector<std::shared_ptr<paradice::beast>> const &beasts)
 {
+    pimpl_->ensure_face_created(hugin::FACE_GM_TOOLS);
     pimpl_->gm_tools_screen_->set_beasts(beasts);
 }
 
@@ -468,6 +459,7 @@ void user_interface::set_beasts(
 // ==========================================================================
 std::vector<std::shared_ptr<paradice::beast>> user_interface::get_beasts() const
 {
+    pimpl_->ensure_face_created(hugin::FACE_GM_TOOLS);
     return pimpl_->gm_tools_screen_->get_beasts();
 }
 
@@ -477,6 +469,7 @@ std::vector<std::shared_ptr<paradice::beast>> user_interface::get_beasts() const
 void user_interface::set_encounters(
     std::vector<std::shared_ptr<paradice::encounter>> const &encounters)
 {
+    pimpl_->ensure_face_created(hugin::FACE_GM_TOOLS);
     pimpl_->gm_tools_screen_->set_encounters(encounters);
 }
 
@@ -486,6 +479,7 @@ void user_interface::set_encounters(
 std::vector<std::shared_ptr<paradice::encounter>> 
 user_interface::get_encounters() const
 {
+    pimpl_->ensure_face_created(hugin::FACE_GM_TOOLS);
     return pimpl_->gm_tools_screen_->get_encounters();
 }
 

--- a/hugin/user_interface.cpp
+++ b/hugin/user_interface.cpp
@@ -156,6 +156,11 @@ private:
         {
             create_main_screen();
         }
+        else if (face_name == hugin::FACE_CHAR_SELECTION
+         && !character_selection_screen_)
+        {
+            create_character_selection_screen();
+        }
     }
     
     // ======================================================================
@@ -163,8 +168,8 @@ private:
     // ======================================================================
     void create_intro_screen()
     {
-        intro_screen_ = std::make_shared<intro_screen>();
         intro_screen_->on_login.connect(self_.on_login);
+        intro_screen_ = std::make_shared<intro_screen>();
         intro_screen_->on_new_account.connect(self_.on_new_account);
 
         active_screen_->add_face(intro_screen_, hugin::FACE_INTRO);
@@ -183,6 +188,22 @@ private:
             
         active_screen_->add_face(
             account_creation_screen_, hugin::FACE_ACCOUNT_CREATION);
+    }
+
+    // ======================================================================
+    // CREATE_CHARACTER_SELECTION_SCREEN
+    // ======================================================================
+    void create_character_selection_screen()
+    {
+        character_selection_screen_ = 
+            std::make_shared<character_selection_screen>();
+        character_selection_screen_->on_new_character.connect(
+            self_.on_new_character);
+        character_selection_screen_->on_character_selected.connect(
+            self_.on_character_selected);
+            
+        active_screen_->add_face(
+            character_selection_screen_, hugin::FACE_CHAR_SELECTION);
     }
 
     // ======================================================================
@@ -223,12 +244,9 @@ user_interface::user_interface(boost::asio::strand &strand)
 
     pimpl_->active_screen_              = std::make_shared<munin::card>();
     pimpl_->character_creation_screen_  = std::make_shared<character_creation_screen>();
-    pimpl_->character_selection_screen_ = std::make_shared<character_selection_screen>();
     pimpl_->gm_tools_screen_            = std::make_shared<gm_tools_screen>();
     pimpl_->status_bar_                 = std::make_shared<munin::status_bar>();
 
-    pimpl_->active_screen_->add_face(
-        pimpl_->character_selection_screen_, hugin::FACE_CHAR_SELECTION);
     pimpl_->active_screen_->add_face(
         pimpl_->character_creation_screen_, hugin::FACE_CHAR_CREATION);
     pimpl_->active_screen_->add_face(
@@ -353,23 +371,6 @@ void user_interface::clear_password_change_screen()
                 pimpl_->password_change_screen_->clear();
             }
         });
-}
-
-// ==========================================================================
-// ON_NEW_CHARACTER
-// ==========================================================================
-void user_interface::on_new_character(std::function<void ()> const &callback)
-{
-    pimpl_->character_selection_screen_->on_new_character(callback);
-}
-
-// ==========================================================================
-// ON_CHARACTER_SELECTED
-// ==========================================================================
-void user_interface::on_character_selected(
-    std::function<void (std::string const &)> const &callback)
-{
-    pimpl_->character_selection_screen_->on_character_selected(callback);
 }
 
 // ==========================================================================

--- a/hugin/user_interface.hpp
+++ b/hugin/user_interface.hpp
@@ -173,25 +173,22 @@ public :
     /// \brief Provide a function to be called if the user hits the 'back'
     /// button on the GM Tools screen
     //* =====================================================================
-    void on_gm_tools_back(std::function<void ()> const &callback);
+    boost::signal<void ()> on_gm_tools_back;
 
     //* =====================================================================
     /// \brief Provide a function to be called if the user inserts a
     /// beast into the current encounter.
     //* =====================================================================
-    void on_gm_fight_beast(
-        std::function<
-            void (std::shared_ptr<paradice::beast> const &)
-        > const &callback);
+    boost::signal<
+        void (std::shared_ptr<paradice::beast> const &)> on_gm_fight_beast;
 
     //* =====================================================================
     /// \brief Provide a function to be called if the user inserts an
     /// encounter into the current encounter.
     //* =====================================================================
-    void on_gm_fight_encounter(
-        std::function<
-            void (std::shared_ptr<paradice::encounter> const &)
-        > const &callback);
+    boost::signal<
+        void (std::shared_ptr<paradice::encounter> const &)
+    > on_gm_fight_encounter;
 
     //* =====================================================================
     /// \brief Shows the active encounter window.

--- a/hugin/user_interface.hpp
+++ b/hugin/user_interface.hpp
@@ -98,17 +98,16 @@ public :
     /// \brief Set a function to be called when the user inputs the details
     /// for the change of a password.
     //* =====================================================================
-    void on_password_changed(
-        std::function<
-            void (std::string const &old_password
-                , std::string const &new_password
-                , std::string const &new_password_verify)> const &callback);
+    boost::signal<
+        void (std::string const &old_password,
+              std::string const &new_password,
+              std::string const &new_password_verify)> on_password_changed;
 
     //* =====================================================================
     /// \brief Set a function to be called when the user cancels the change
     /// of a password.
     //* =====================================================================
-    void on_password_change_cancelled(std::function<void ()> const &callback);
+    boost::signal<void ()> on_password_change_cancelled;
 
     //* =====================================================================
     /// \brief Set a function to be called when the user inputs a name

--- a/hugin/user_interface.hpp
+++ b/hugin/user_interface.hpp
@@ -148,15 +148,13 @@ public :
     /// \brief Provide a function to be called if the user opts to create
     /// a new character.o
     //* =====================================================================
-    void on_new_character(
-        std::function<void ()> const &callback);
-
+    boost::signal<void ()> on_new_character;
+    
     //* =====================================================================
     /// \brief Provide a function to be called if the user opts to use an
     /// existing character.
     //* =====================================================================
-    void on_character_selected(
-        std::function<void (std::string const &)> const &callback);
+    boost::signal<void (std::string const &name)> on_character_selected;
 
     //* =====================================================================
     /// \brief Provide a function to be called if the user creates a new

--- a/hugin/user_interface.hpp
+++ b/hugin/user_interface.hpp
@@ -127,17 +127,16 @@ public :
     /// \brief Set a function to be called when the user inputs the details
     /// for the creation of an account.
     //* =====================================================================
-    void on_account_created(
-        std::function<
-            void (std::string const &account_name
-                , std::string const &password
-                , std::string const &password_verify)> const &callback);
-
+    boost::signal<
+        void (std::string const &account_name,
+              std::string const &password,
+              std::string const &password_verify)> on_account_created;
+              
     //* =====================================================================
     /// \brief Set a function to be called when the user cancels the creation
     /// of an account.
     //* =====================================================================
-    void on_account_creation_cancelled(std::function<void ()> const &callback);
+    boost::signal<void ()> on_account_creation_cancelled;
 
     //* =====================================================================
     /// \brief Set a function to be called when the user inputs a command

--- a/hugin/user_interface.hpp
+++ b/hugin/user_interface.hpp
@@ -113,15 +113,15 @@ public :
     /// \brief Set a function to be called when the user inputs a name
     /// and password on the intro screen.
     //* =====================================================================
-    void on_login(
-        std::function<
-            void (std::string const &, std::string const &)> const &callback);
+    boost::signal<
+        void (std::string const &username,
+              std::string const &hashed_password)> on_login;
 
     //* =====================================================================
     /// \brief Set a function to be called when the user wants to create
     /// a new account.
     //* =====================================================================
-    void on_new_account(std::function<void ()> const &callback);
+    boost::signal<void ()> on_new_account;
 
     //* =====================================================================
     /// \brief Set a function to be called when the user inputs the details

--- a/hugin/user_interface.hpp
+++ b/hugin/user_interface.hpp
@@ -160,15 +160,14 @@ public :
     /// \brief Provide a function to be called if the user creates a new
     /// character.
     //* =====================================================================
-    void on_character_created(
-        std::function<void (std::string const &, bool)> const &callback);
+    boost::signal<
+        void (std::string const &name, bool is_gm)> on_character_created;
 
     //* =====================================================================
     /// \brief Provide a function to be called if the user decides to cancel
     /// the creation of a character.
     //* =====================================================================
-    void on_character_creation_cancelled(
-        std::function<void ()> const &callback);
+    boost::signal<void ()> on_character_creation_cancelled;
 
     //* =====================================================================
     /// \brief Provide a function to be called if the user hits the 'back'

--- a/hugin/user_interface.hpp
+++ b/hugin/user_interface.hpp
@@ -142,12 +142,11 @@ public :
     /// \brief Set a function to be called when the user inputs a command
     /// on the main screen.
     //* =====================================================================
-    void on_input_entered(
-        std::function<void (std::string const &)> const &callback);
+    boost::signal<void (std::string const &input)> on_input_entered;
 
     //* =====================================================================
     /// \brief Provide a function to be called if the user opts to create
-    /// a new character.
+    /// a new character.o
     //* =====================================================================
     void on_new_character(
         std::function<void ()> const &callback);
@@ -282,7 +281,7 @@ public :
     /// \brief Set up a callback for when the close icon on the help
     /// window is clicked.
     //* =====================================================================
-    void on_help_closed(std::function<void ()> const &callback);
+    boost::signal<void ()> on_help_closed;
 
     //* =====================================================================
     /// \brief Sets the text contained in the Help window.

--- a/munin/card.cpp
+++ b/munin/card.cpp
@@ -109,6 +109,10 @@ void card::add_face(
         {
             on_cursor_position_changed(pos);
         });
+    
+    // As the component has just been added to this, it will need to be
+    // laid out.
+    comp->layout();
 }
 
 // ==========================================================================

--- a/munin/text_area.cpp
+++ b/munin/text_area.cpp
@@ -493,7 +493,10 @@ terminalpp::point text_area::do_get_cursor_position() const
 // ==========================================================================
 void text_area::do_set_cursor_position(terminalpp::point const &position)
 {
-    pimpl_->set_cursor_position(position);
+    if (position != get_cursor_position())
+    {
+        pimpl_->set_cursor_position(position);
+    }        
 }
 
 // ==========================================================================

--- a/paradice/client.cpp
+++ b/paradice/client.cpp
@@ -215,7 +215,7 @@ public :
             });
 
         // USER INTERFACE CALLBACKS
-        user_interface_->on_input_entered(
+        user_interface_->on_input_entered.connect(
             [this](auto const &input)
             {
                 this->on_input_entered(input);
@@ -287,7 +287,7 @@ public :
                 this->on_gm_fight_encounter(encounter);
             });
 
-        user_interface_->on_help_closed(
+        user_interface_->on_help_closed.connect(
             [this]
             {
                 this->on_help_closed();

--- a/paradice/client.cpp
+++ b/paradice/client.cpp
@@ -233,13 +233,13 @@ public :
                 this->on_new_account();
             });
 
-        user_interface_->on_account_created(
+        user_interface_->on_account_created.connect(
             [this](auto const &name, auto const &pwd, auto const &pwd_verify)
             {
                 this->on_account_created(name, pwd, pwd_verify);
             });
 
-        user_interface_->on_account_creation_cancelled(
+        user_interface_->on_account_creation_cancelled.connect(
             [this]
             {
                 this->on_account_creation_cancelled();

--- a/paradice/client.cpp
+++ b/paradice/client.cpp
@@ -257,13 +257,13 @@ public :
                 this->on_character_selected(idx);
             });
 
-        user_interface_->on_character_created(
+        user_interface_->on_character_created.connect(
             [this](auto const &name, auto const &is_gm)
             {
                 this->on_character_created(name, is_gm);
             });
 
-        user_interface_->on_character_creation_cancelled(
+        user_interface_->on_character_creation_cancelled.connect(
             [this]
             {
                 this->on_character_creation_cancelled();

--- a/paradice/client.cpp
+++ b/paradice/client.cpp
@@ -269,19 +269,19 @@ public :
                 this->on_character_creation_cancelled();
             });
 
-        user_interface_->on_gm_tools_back(
+        user_interface_->on_gm_tools_back.connect(
             [this]
             {
                 this->on_gm_tools_back();
             });
 
-        user_interface_->on_gm_fight_beast(
+        user_interface_->on_gm_fight_beast.connect(
             [this](auto const &beast)
             {
                 this->on_gm_fight_beast(beast);
             });
 
-        user_interface_->on_gm_fight_encounter(
+        user_interface_->on_gm_fight_encounter.connect(
             [this](auto const &encounter)
             {
                 this->on_gm_fight_encounter(encounter);

--- a/paradice/client.cpp
+++ b/paradice/client.cpp
@@ -221,13 +221,13 @@ public :
                 this->on_input_entered(input);
             });
 
-        user_interface_->on_login(
+        user_interface_->on_login.connect(
             [this](auto const &name, auto const &pwd)
             {
                 this->on_login(name, pwd);
             });
 
-        user_interface_->on_new_account(
+        user_interface_->on_new_account.connect(
             [this]
             {
                 this->on_new_account();

--- a/paradice/client.cpp
+++ b/paradice/client.cpp
@@ -293,7 +293,7 @@ public :
                 this->on_help_closed();
             });
 
-        user_interface_->on_password_changed(
+        user_interface_->on_password_changed.connect(
             [this](
                 auto const &old_pwd,
                 auto const &new_pwd,
@@ -302,7 +302,7 @@ public :
                 this->on_password_changed(old_pwd, new_pwd, new_pwd_verify);
             });
 
-        user_interface_->on_password_change_cancelled(
+        user_interface_->on_password_change_cancelled.connect(
             [this]
             {
                 this->on_password_change_cancelled();

--- a/paradice/client.cpp
+++ b/paradice/client.cpp
@@ -245,13 +245,13 @@ public :
                 this->on_account_creation_cancelled();
             });
 
-        user_interface_->on_new_character(
+        user_interface_->on_new_character.connect(
             [this]
             {
                 this->on_new_character();
             });
 
-        user_interface_->on_character_selected(
+        user_interface_->on_character_selected.connect(
             [this](auto const &idx)
             {
                 this->on_character_selected(idx);


### PR DESCRIPTION
Ensured that all root GUI components are now lazily initialized.

This means that, for example in the happy path, only the intro, character selection, and main screens will be instantiated.  The upside of this is that heavier UI elements such as the GM tools screen are not created on log-in.  This has a noticeable effect on the time between the user connecting and seeing the initial screen.

Also threw in a couple of other optimizations, including text area checking the current cursor position when having it set.  This results in a lot of skipped callback code when, for example, a user is scrolling against the edge of the text box.

Closes #186.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kazdragon/paradice9/187)
<!-- Reviewable:end -->
