### PR TITLE
Changed glyphs for dropdown lists and toggle buttons

### DIFF
--- a/munin/include/munin/unicode_glyphs.hpp
+++ b/munin/include/munin/unicode_glyphs.hpp
@@ -88,6 +88,8 @@ static constexpr terminalpp::glyph const mix_lined_vcross("\U0000256A");
 // Other drawing characters.
 static constexpr terminalpp::glyph const left_guillemet("\U000000AB");
 static constexpr terminalpp::glyph const right_guillemet("\U000000BB");
+static constexpr terminalpp::glyph const light_cross("\U00002573");
+static constexpr terminalpp::glyph const down_pointing_triangle("\U000025BE");
 
 }}
 

--- a/munin/src/dropdown_list.cpp
+++ b/munin/src/dropdown_list.cpp
@@ -298,7 +298,7 @@ dropdown_list::dropdown_list()
         ), COMPASS_LAYOUT_EAST);
 
     // Construct the centre bar |   |V|
-    pimpl_->dropdown_button_ = make_image("V");
+    pimpl_->dropdown_button_ = make_image(terminalpp::string({down_pointing_triangle}));
     pimpl_->dropdown_button_->set_can_focus(true);
     pimpl_->selected_text_ = make_image(" ");
 

--- a/munin/src/dropdown_list.cpp
+++ b/munin/src/dropdown_list.cpp
@@ -100,6 +100,13 @@ protected :
     odin::u32 preferred_height_;
 };
 
+static std::unique_ptr<fixed_height_layout> make_fixed_height_layout(
+    odin::u32 preferred_height)
+{
+    return std::unique_ptr<fixed_height_layout>(
+        new fixed_height_layout(preferred_height));
+}
+
 }
 
 // ==========================================================================
@@ -332,13 +339,12 @@ dropdown_list::dropdown_list()
     // ======================================================================
     // Construct the dropdown list.
     // ======================================================================
-    pimpl_->list_ = std::make_shared<list>();
+    pimpl_->list_ = make_list();
     pimpl_->list_->on_item_changed.connect(
         [this](auto idx)
         {
             pimpl_->on_item_changed(idx);
         });
-    auto scroller = std::make_shared<scroll_pane>(pimpl_->list_, false);
 
     // Now put them together.
     pimpl_->dropdown_ = view(
@@ -346,8 +352,8 @@ dropdown_list::dropdown_list()
         // Put the scrollpane in a fixed-height layout so that it doesn't 
         // prefer to take up the entire screen.
         view(
-            std::unique_ptr<fixed_height_layout>(new fixed_height_layout(7)),
-            scroller
+            make_fixed_height_layout(7),
+            make_scroll_pane(pimpl_->list_, false)
         ), COMPASS_LAYOUT_CENTRE,
         // Create a spacer to the right, so that the list is offset by the
         // width of the dropdown button.

--- a/munin/src/toggle_button.cpp
+++ b/munin/src/toggle_button.cpp
@@ -30,11 +30,19 @@
 #include "munin/grid_layout.hpp"
 #include "munin/image.hpp"
 #include "munin/solid_frame.hpp"
+#include "munin/unicode_glyphs.hpp"
 #include <terminalpp/ansi/mouse.hpp>
 #include <terminalpp/string.hpp>
 #include <terminalpp/virtual_key.hpp>
 
 namespace munin {
+
+namespace {
+
+static terminalpp::string const selected_image = {light_cross};
+static terminalpp::string const deselected_image = " ";
+
+}
 
 // ==========================================================================
 // TOGGLE_BUTTON::IMPLEMENTATION STRUCTURE
@@ -51,7 +59,8 @@ struct toggle_button::impl
 toggle_button::toggle_button(bool default_state)
   : pimpl_(std::make_shared<impl>())
 {
-    pimpl_->image_ = make_image(default_state ? "X" : " ");
+    pimpl_->image_ = make_image(
+        default_state ? selected_image : deselected_image);
     pimpl_->image_->set_can_focus(true);
 
     pimpl_->state_ = default_state;
@@ -80,7 +89,7 @@ void toggle_button::set_toggle(bool toggle)
     {
         pimpl_->state_ = toggle;
 
-        pimpl_->image_->set_image(toggle ? "X" : " ");
+        pimpl_->image_->set_image(toggle ? selected_image : deselected_image);
     }
 }
 


### PR DESCRIPTION
Now that we're using Unicode, a couple of alternatives present themselves.
Instead of the letter X, there is a broad cross glyph in the box drawing
characters.  Likewise, there's a downward triangle instead of the letter V
for the dropdown action.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/paradice9/207)
<!-- Reviewable:end -->
